### PR TITLE
unmarshal null into empty

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"4d63.com/optional"
 )
@@ -277,7 +280,7 @@ func Example_jsonMarshalPresent() {
 	// }
 }
 
-func Example_jsonUnmarshalEmpty() {
+func TestExample_jsonUnmarshalEmpty(t *testing.T) {
 	s := struct {
 		Bool    optional.Optional[bool]      `json:"bool"`
 		Byte    optional.Optional[byte]      `json:"byte"`
@@ -335,6 +338,64 @@ func Example_jsonUnmarshalEmpty() {
 	// Uint64: false
 	// Uint: false
 	// Uintptr: false
+
+	t.Run("unmarshal null values to empty", func(t *testing.T) {
+		s := struct {
+			Bool    optional.Optional[bool]      `json:"bool"`
+			Byte    optional.Optional[byte]      `json:"byte"`
+			Float32 optional.Optional[float32]   `json:"float32"`
+			Float64 optional.Optional[float64]   `json:"float64"`
+			Int16   optional.Optional[int16]     `json:"int16"`
+			Int32   optional.Optional[int32]     `json:"int32"`
+			Int64   optional.Optional[int64]     `json:"int64"`
+			Int     optional.Optional[int]       `json:"int"`
+			Rune    optional.Optional[rune]      `json:"rune"`
+			String  optional.Optional[string]    `json:"string"`
+			Time    optional.Optional[time.Time] `json:"time"`
+			Uint16  optional.Optional[uint16]    `json:"uint16"`
+			Uint32  optional.Optional[uint32]    `json:"uint32"`
+			Uint64  optional.Optional[uint64]    `json:"uint64"`
+			Uint    optional.Optional[uint]      `json:"uint"`
+			Uintptr optional.Optional[uintptr]   `json:"uintptr"`
+		}{}
+
+		x := `{
+		  "float64": null,
+		  "bool": null,
+		  "byte": null,
+		  "float32": null,
+		  "int16": null,
+		  "int32": null,
+		  "int64": null,
+		  "int": null,
+		  "rune": null,
+		  "string": null,
+		  "time": null,
+		  "uint16": null,
+		  "uint32": null,
+		  "uint64": null,
+		  "uint": null,
+		  "uintptr": null
+		}`
+		json.Unmarshal([]byte(x), &s)
+		assert.False(t, s.Bool.IsPresent())
+		assert.False(t, s.Byte.IsPresent())
+		assert.False(t, s.Float32.IsPresent())
+		assert.False(t, s.Float64.IsPresent())
+		assert.False(t, s.Int16.IsPresent())
+		assert.False(t, s.Int32.IsPresent())
+		assert.False(t, s.Int64.IsPresent())
+		assert.False(t, s.Int.IsPresent())
+		assert.False(t, s.Rune.IsPresent())
+		assert.False(t, s.String.IsPresent())
+		assert.False(t, s.Time.IsPresent())
+		assert.False(t, s.Uint16.IsPresent())
+		assert.False(t, s.Uint32.IsPresent())
+		assert.False(t, s.Uint64.IsPresent())
+		assert.False(t, s.Uint64.IsPresent())
+		assert.False(t, s.Uint.IsPresent())
+		assert.False(t, s.Uint.IsPresent())
+	})
 }
 
 func Example_jsonUnmarshalPresent() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module 4d63.com/optional
 
 go 1.18
+
+require github.com/stretchr/testify v1.7.2
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/optional.go
+++ b/optional.go
@@ -99,6 +99,11 @@ func (o Optional[T]) MarshalJSON() (data []byte, err error) {
 
 // UnmarshalJSON unmarshals the JSON into a value wrapped by this optional.
 func (o *Optional[T]) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*o = Empty[T]()
+		return nil
+	}
+
 	var v T
 	err := json.Unmarshal(data, &v)
 	if err != nil {


### PR DESCRIPTION
Currently this JSON `{"value":null}` will be unmarshalled into `optional.Of[T](0)` assuming T is numeric

Fix: unmarshal null to `Empty[T]`

